### PR TITLE
🔒 Remove debug console logs in useTimer hook

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -19,5 +19,8 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      'no-console': ['warn', { allow: ['warn', 'error'] }],
+    },
   },
 ])

--- a/src/hooks/useTimer.ts
+++ b/src/hooks/useTimer.ts
@@ -5,14 +5,12 @@ const useTimer = (seconds: number) => {
   const intervalRef = useRef<number | null>(null);
 
   const startCountdown = useCallback(() => {
-    console.log("starting countdown...");
     intervalRef.current = setInterval(() => {
       setTimeLeft((timeLeft) => timeLeft - 1);
     }, 1000);
   }, [setTimeLeft]);
 
   const resetCountdown = useCallback(() => {
-    console.log("resetting countdown...");
     if (intervalRef.current) {
       clearInterval(intervalRef.current);
     }
@@ -22,7 +20,6 @@ const useTimer = (seconds: number) => {
   // when the countdown reaches 0, clear the countdown interval
   useEffect(() => {
     if (!timeLeft && intervalRef.current) {
-      console.log("clearing timer...");
       clearInterval(intervalRef.current);
     }
   }, [timeLeft, intervalRef]);


### PR DESCRIPTION
🎯 **What:** Removed `console.log` statements from `src/hooks/useTimer.ts` and added an ESLint rule to prevent future `console.log` usage.
⚠️ **Risk:** Exposing debug information in production code can lead to potential information leakage and performance overhead. It also clutters the console, making legitimate errors harder to spot.
🛡️ **Solution:** Removed the logs and configured ESLint with `no-console: ['warn', { allow: ['warn', 'error'] }]` to enforce cleaner code while allowing necessary warnings and errors.

---
*PR created automatically by Jules for task [16337110032944769597](https://jules.google.com/task/16337110032944769597) started by @7sg56*